### PR TITLE
fix(SOLVIT25-171) :: 모임관리 멤버 모달 제3자 본인은 추방 안뜨게

### DIFF
--- a/src/containers/meeting/third-party/MemberModal/index.tsx
+++ b/src/containers/meeting/third-party/MemberModal/index.tsx
@@ -7,6 +7,7 @@ import { useApollo } from "@/lib/apolloClient";
 import { GroupService } from "@/services/group";
 import type { GroupMember, GroupParticipationRequest } from "@/types/group";
 import { useAlertStore } from "@/store/alert";
+import { useUserStore } from "@/store/user";
 
 interface MemberModalProps {
   groupId?: string;
@@ -16,6 +17,7 @@ interface MemberModalProps {
 export default function MemberModal({ groupId, onDone }: MemberModalProps) {
   const client = useApollo();
   const { success, error } = useAlertStore();
+  const { userId: currentUserId } = useUserStore();
   const [members, setMembers] = useState<GroupMember[]>([]);
   const [requests, setRequests] = useState<GroupParticipationRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -174,7 +176,11 @@ export default function MemberModal({ groupId, onDone }: MemberModalProps) {
                     </S.Desc>
                   </S.InfoCol>
                 </div>
-                <S.ExpelBtn onClick={() => handleExpelClick(idx)}>추방</S.ExpelBtn>
+                {member.userId !== currentUserId ? (
+                  <S.ExpelBtn onClick={() => handleExpelClick(idx)}>추방</S.ExpelBtn>
+                ) : (
+                  <div style={{ width: '80px' }} />
+                )}
               </S.Card>
             ))}
           </div>


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 모임관리 멤버 모달 제3자 본인은 추방 안뜨게 작업을 진행합니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

-


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 멤버 목록에서 현재 사용자 본인의 추방 버튼이 비활성화되었습니다. 이제 다른 멤버들에 대해서만 추방 기능이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->